### PR TITLE
Workaround for installation issues with picamera2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "autosemver"]
 build-backend = "setuptools.build_meta"
 
 [project]
-dependencies = ["astral", "autosemver", "boto3", "picamzero", "platformdirs", "python-dotenv", "pyyaml"]
+dependencies = ["astral", "autosemver", "boto3", "picamzero", "platformdirs", "python-dotenv", "pyyaml", "opencv-python-headless==4.11.0.86", "picamera2==0.3.27"]
 requires-python = ">=3.9"
 name = "dri-raspberrycam"
 dynamic = ["version"]


### PR DESCRIPTION
See #37 - explicitly pin to older versions of `picamera2` and `opencv-python-headless`